### PR TITLE
allowed command to return null or DTO instance

### DIFF
--- a/src/AbstractCommandHandler.php
+++ b/src/AbstractCommandHandler.php
@@ -15,6 +15,7 @@ namespace Gears\CQRS;
 
 use Gears\CQRS\Exception\InvalidCommandException;
 use Gears\CQRS\Exception\InvalidQueryException;
+use Gears\DTO\DTO;
 
 abstract class AbstractCommandHandler implements CommandHandler
 {
@@ -23,7 +24,7 @@ abstract class AbstractCommandHandler implements CommandHandler
      *
      * @throws InvalidQueryException
      */
-    final public function handle(Command $command): void
+    final public function handle(Command $command): ?DTO
     {
         if ($command->getCommandType() !== $this->getSupportedCommandType()) {
             throw new InvalidCommandException(\sprintf(
@@ -49,5 +50,5 @@ abstract class AbstractCommandHandler implements CommandHandler
      *
      * @param Command $command
      */
-    abstract protected function handleCommand(Command $command): void;
+    abstract protected function handleCommand(Command $command): ?DTO;
 }

--- a/src/CommandHandler.php
+++ b/src/CommandHandler.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Gears\CQRS;
 
+use Gears\DTO\DTO;
+
 interface CommandHandler
 {
     /**
@@ -20,5 +22,5 @@ interface CommandHandler
      *
      * @param Command $command
      */
-    public function handle(Command $command): void;
+    public function handle(Command $command): ?DTO;
 }

--- a/tests/CQRS/AbstractCommandHandlerTest.php
+++ b/tests/CQRS/AbstractCommandHandlerTest.php
@@ -17,6 +17,7 @@ use Gears\CQRS\Exception\InvalidCommandException;
 use Gears\CQRS\Tests\Stub\AbstractCommandHandlerStub;
 use Gears\CQRS\Tests\Stub\AbstractCommandStub;
 use Gears\CQRS\Tests\Stub\AbstractEmptyCommandStub;
+use Gears\CQRS\Tests\Stub\DTOStub;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -38,9 +39,9 @@ class AbstractCommandHandlerTest extends TestCase
     public function testHandling(): void
     {
         $handler = new AbstractCommandHandlerStub();
-        $handler->handle(AbstractCommandStub::instance());
+        $result = $handler->handle(AbstractCommandStub::instance());
 
-        static::assertTrue(true);
+        static::assertTrue($result instanceof DTOStub);
     }
 
     public function testReconstitute(): void

--- a/tests/CQRS/AbstractEmptyCommandTest.php
+++ b/tests/CQRS/AbstractEmptyCommandTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Gears\CQRS\Tests;
 
 use Gears\CQRS\Exception\CommandException;
+use Gears\CQRS\Tests\Stub\AbstractEmptyCommandHandlerStub;
 use Gears\CQRS\Tests\Stub\AbstractEmptyCommandStub;
 use PHPUnit\Framework\TestCase;
 
@@ -52,5 +53,13 @@ class AbstractEmptyCommandTest extends TestCase
         );
 
         \unserialize('O:46:"Gears\CQRS\Tests\Stub\AbstractEmptyCommandStub":0:{}');
+    }
+
+    public function testHandling(): void
+    {
+        $handler = new AbstractEmptyCommandHandlerStub();
+        $result = $handler->handle(AbstractEmptyCommandStub::instance());
+
+        static::assertNull($result);
     }
 }

--- a/tests/CQRS/Stub/AbstractCommandHandlerStub.php
+++ b/tests/CQRS/Stub/AbstractCommandHandlerStub.php
@@ -15,6 +15,7 @@ namespace Gears\CQRS\Tests\Stub;
 
 use Gears\CQRS\AbstractCommandHandler;
 use Gears\CQRS\Command;
+use Gears\DTO\DTO;
 
 /**
  * Abstract command handler stub class.
@@ -32,7 +33,8 @@ class AbstractCommandHandlerStub extends AbstractCommandHandler
     /**
      * {@inheritdoc}
      */
-    protected function handleCommand(Command $command): void
+    protected function handleCommand(Command $command): ?DTO
     {
+        return DTOStub::instance();
     }
 }

--- a/tests/CQRS/Stub/AbstractEmptyCommandHandlerStub.php
+++ b/tests/CQRS/Stub/AbstractEmptyCommandHandlerStub.php
@@ -15,6 +15,7 @@ namespace Gears\CQRS\Tests\Stub;
 
 use Gears\CQRS\AbstractCommandHandler;
 use Gears\CQRS\Command;
+use Gears\DTO\DTO;
 
 /**
  * Abstract command handler stub class.
@@ -32,7 +33,8 @@ class AbstractEmptyCommandHandlerStub extends AbstractCommandHandler
     /**
      * {@inheritdoc}
      */
-    protected function handleCommand(Command $command): void
+    protected function handleCommand(Command $command): ?DTO
     {
+        return null;
     }
 }


### PR DESCRIPTION
Replaced `void` with `?DTO` in `AbstractCommandHandler` to allow to return state of command execution.